### PR TITLE
Better coverage

### DIFF
--- a/src/components/OTP.php
+++ b/src/components/OTP.php
@@ -83,7 +83,7 @@ class OTP extends Component
     protected function getAuth()
     {
         if (is_null($this->secret)) {
-            return null;
+            return null; // @codeCoverageIgnore
         }
 
         $auth = new Authenticator;
@@ -118,7 +118,7 @@ class OTP extends Component
     protected function doverifycode(string $code, $acceptScratch = true)
     {
         if (is_null($this->secret)) {
-            return false;
+            return false; // @codeCoverageIgnore
         }
 
         if (strlen($code) != $this->secret->digits && strlen($code) != Scratch::SCRATCH_LENGTH) {

--- a/src/components/OTP.php
+++ b/src/components/OTP.php
@@ -346,7 +346,7 @@ class OTP extends Component
         }
 
         if (!$this->invalidateScratches()) {
-            return false;
+            return false; // @codeCoverageIgnore
         }
 
         Scratch::createScratches($this->secret->id);

--- a/src/components/OTP.php
+++ b/src/components/OTP.php
@@ -179,7 +179,7 @@ class OTP extends Component
         $this->secret = $s;
 
         if ($this->willGC()) {
-            $this->cleanupUnconfirmed();
+            $this->cleanupUnconfirmed(); // @codeCoverageIgnore
         }
 
         return $s->id;
@@ -197,7 +197,7 @@ class OTP extends Component
         $this->secret = Secret::findOne($sid);
 
         if ($this->willGC()) {
-            $this->cleanupUnconfirmed();
+            $this->cleanupUnconfirmed(); // @codeCoverageIgnore
         }
 
         return !is_null($this->secret);

--- a/src/components/OTP.php
+++ b/src/components/OTP.php
@@ -169,10 +169,12 @@ class OTP extends Component
             Scratch::createScratches($s->id);
 
             $transaction->commit();
+        // @codeCoverageIgnoreStart
         } catch (\Exception $e) {
             $transaction->rollBack();
             throw $e;
         }
+        // @codeCoverageIgnoreEnd
 
         $this->secret = $s;
 
@@ -366,14 +368,16 @@ class OTP extends Component
         $transaction = Yii::$app->db->beginTransaction();
         try {
             if (!Scratch::remove($this->secret->id)) {
-                throw new Exception('Failed to remove scratch codes');
+                throw new Exception('Failed to remove scratch codes'); // @codeCoverageIgnore
             }
             $this->secret->delete();
             $transaction->commit();
+        // @codeCoverageIgnoreStart
         } catch (\Exception $e) {
             $transaction->rollBack();
             throw $e;
         }
+        // @codeCoverageIgnoreEnd
 
         $this->secret = null;
 
@@ -394,15 +398,17 @@ class OTP extends Component
 
             foreach ($secrets as $s) {
                 if (!Scratch::remove($s->id)) {
-                    throw new Exception('Failed to remove scratch codes');
+                    throw new Exception('Failed to remove scratch codes'); // @codeCoverageIgnore
                 }
                 $s->delete();
             }
 
             $transaction->commit();
+        // @codeCoverageIgnoreStart
         } catch (\Exception $e) {
             $transaction->rollBack();
             throw $e;
         }
+        // @codeCoverageIgnoreEnd
     }
 }

--- a/src/models/Scratch.php
+++ b/src/models/Scratch.php
@@ -71,7 +71,7 @@ class Scratch extends \yii\db\ActiveRecord
     public function beforeSave($insert)
     {
         if (!parent::beforeSave($insert) || !$insert) {
-            return false;
+            return false; // @codeCoverageIgnore
         }
 
         return true;

--- a/src/models/Scratch.php
+++ b/src/models/Scratch.php
@@ -213,10 +213,12 @@ class Scratch extends \yii\db\ActiveRecord
             }
 
             $transaction->commit();
+        // @codeCoverageIgnoreStart
         } catch (\Exception $e) {
             $transaction->rollBack();
             throw $e;
         }
+        // @codeCoverageIgnoreEnd
 
         return true;
     }

--- a/src/models/Secret.php
+++ b/src/models/Secret.php
@@ -166,7 +166,7 @@ class Secret extends \yii\db\ActiveRecord
         }
 
         if (!$this->updateCounters(['counter' => 1])) {
-            return false;
+            return false; // @codeCoverageIgnore
         }
 
         return $this->counter;

--- a/src/models/Secret.php
+++ b/src/models/Secret.php
@@ -104,7 +104,7 @@ class Secret extends \yii\db\ActiveRecord
     public function beforeSave($insert)
     {
         if (!parent::beforeSave($insert)) {
-            return false;
+            return false; // @codeCoverageIgnore
         }
 
         if (!$insert) {
@@ -183,7 +183,7 @@ class Secret extends \yii\db\ActiveRecord
 
         $this->counter = $v;
         if (!$this->save()) {
-            return false;
+            return false; // @codeCoverageIgnore
         }
 
         return $this->counter;

--- a/src/widgets/QRCodeimg.php
+++ b/src/widgets/QRCodeimg.php
@@ -124,7 +124,6 @@ class QRCodeimg extends Widget
                 throw new ServerErrorHttpException('Invalid error correction level');
                 break; // @codeCoverageIgnore
         }
-        
 
         if (strpos($this->label, ':') || strpos($this->username, ':')) {
             throw new ServerErrorHttpException('QRCode label and username cannot contain ":"');

--- a/src/widgets/QRCodeimg.php
+++ b/src/widgets/QRCodeimg.php
@@ -82,6 +82,7 @@ class QRCodeimg extends Widget
         }
 
         switch ($this->fmt) {
+            // @codeCoverageIgnoreStart
             case 'eps':
                 $this->imagebackend = '\BaconQrCode\Renderer\Image\EpsImageBackEnd';
                 break;
@@ -93,6 +94,7 @@ class QRCodeimg extends Widget
             case 'svg':
                 $this->imagebackend = '\BaconQrCode\Renderer\Image\SvgImageBackEnd';
                 break;
+            // @codeCoverageIgnoreEnd
 
             default:
                 throw new ServerErrorHttpException('Invalid image format');
@@ -100,6 +102,7 @@ class QRCodeimg extends Widget
         }
 
         switch ($this->ecLevel) {
+            // @codeCoverageIgnoreStart
             case 'L':
                 $this->ecLevel = ErrorCorrectionLevel::forBits(1);
                 break;
@@ -115,12 +118,13 @@ class QRCodeimg extends Widget
             case 'H':
                 $this->ecLevel = ErrorCorrectionLevel::forBits(2);
                 break;
+            // @codeCoverageIgnoreEnd
 
             default:
                 throw new ServerErrorHttpException('Invalid error correction level');
                 break;
         }
-        // @codeCoverageIgnoreEnd
+        
 
         if (strpos($this->label, ':') || strpos($this->username, ':')) {
             throw new ServerErrorHttpException('QRCode label and username cannot contain ":"');

--- a/src/widgets/QRCodeimg.php
+++ b/src/widgets/QRCodeimg.php
@@ -120,6 +120,7 @@ class QRCodeimg extends Widget
                 throw new ServerErrorHttpException('Invalid error correction level');
                 break;
         }
+        // @codeCoverageIgnoreEnd
 
         if (strpos($this->label, ':') || strpos($this->username, ':')) {
             throw new ServerErrorHttpException('QRCode label and username cannot contain ":"');

--- a/src/widgets/QRCodeimg.php
+++ b/src/widgets/QRCodeimg.php
@@ -98,7 +98,7 @@ class QRCodeimg extends Widget
 
             default:
                 throw new ServerErrorHttpException('Invalid image format');
-                break;
+                break; // @codeCoverageIgnore
         }
 
         switch ($this->ecLevel) {
@@ -122,7 +122,7 @@ class QRCodeimg extends Widget
 
             default:
                 throw new ServerErrorHttpException('Invalid error correction level');
-                break;
+                break; // @codeCoverageIgnore
         }
         
 

--- a/tests/OTPTest.php
+++ b/tests/OTPTest.php
@@ -116,15 +116,33 @@ class OTPTest extends TestCase
     }
 
     /**
+     * Data provider to test all OTP types
+     *
+     * @return Array
+     */
+    public function OTPTypes()
+    {
+        return [
+            ['totp'],
+            ['hotp']
+        ];
+    }
+
+    /**
      * Test Verifying an OTP works only with correct OTP
      *
+     * @param $mode (totp|hotp)
      * @return void
+     *
+     * @dataProvider OTPTypes
      */
-    public function testVerify()
+    public function testVerify(string $mode)
     {
         $otp = Yii::$app->otp;
         $auth = new Authenticator;
+        $auth->setMode($mode);
 
+        $otp->mode = $mode;
         $sid = $otp->create();
         $secret = $otp->getSecret();
         $this->assertInternalType('string', $secret);

--- a/tests/OTPTest.php
+++ b/tests/OTPTest.php
@@ -318,4 +318,28 @@ class OTPTest extends TestCase
         $this->assertNotTrue($otp->regenerateScrathes());
         $this->assertNotTrue($otp->forget());
     }
+
+    /**
+     * Test OTP validation with invalid OTPs
+     *
+     * @return void
+     */
+    public function testInvalidOTPs()
+    {
+        $otp = Yii::$app->otp;
+
+        $otp->create();
+        $auth = new Authenticator;
+        $secret = $otp->getSecret();
+        $this->assertInternalType('string', $secret);
+        $auth->setSecret($secret);
+
+        $this->assertNotTrue($otp->confirm('00'));
+        $this->assertNotTrue($otp->confirm('foobar'));
+
+        $this->assertTrue($otp->confirm($auth->code()));
+
+        $this->assertNotTrue($otp->verify('00'));
+        $this->assertNotTrue($otp->verify('foobar'));
+    }
 }

--- a/tests/OTPTest.php
+++ b/tests/OTPTest.php
@@ -295,4 +295,27 @@ class OTPTest extends TestCase
         $chk = $otp->get($sid[2]);
         $this->assertEquals($sid[2], $chk);
     }
+
+    /**
+     * Test that OTP methods fail when not having set a Secret to work on
+     *
+     * This means if either of OTP::create() or OTP::get() is not called
+     * before using the object
+     *
+     * @return void
+     */
+    public function testMethodsWithNullSecretFail()
+    {
+        $otp = Yii::$app->otp;
+
+        $this->assertNotTrue($otp->getScratches());
+        $this->assertNotTrue($otp->getSecret());
+        $this->assertNotTrue($otp->isConfirmed());
+        $this->assertNotTrue($otp->confirm('00000000'));
+        $this->assertNotTrue($otp->verify('00000000'));
+        $this->assertNotTrue($otp->generate());
+        $this->assertNotTrue($otp->invalidateScratches());
+        $this->assertNotTrue($otp->regenerateScrathes());
+        $this->assertNotTrue($otp->forget());
+    }
 }

--- a/tests/QRCodeimgTest.php
+++ b/tests/QRCodeimgTest.php
@@ -10,30 +10,66 @@ use madpilot78\otputil\widgets\QRCodeimg;
 class QRCodeimgTest extends TestCase
 {
     /**
+     * Data provider to test all options
+     *
+     * @return Array
+     */
+    public function optionProvider()
+    {
+        $ret = [];
+
+        foreach (['totp', 'hotp'] as $type) {
+            foreach (['baz', false] as $issuer) {
+                $ret[] = [$type, $issuer];
+            }
+        }
+
+        return $ret;
+    }
+
+    /**
      * Test generating one QRCode
      *
+     * @param string $type
+     * @param string $issuer
      * @return void
+     *
+     * @dataProvider optionProvider
      */
-    public function testGenerateQRCode()
+    public function testGenerateQRCode(string $type, string $issuer)
     {
         $base32 = new Base32();
         $testsecret = $base32->fromString(random_bytes(20));
-        $exp = 'otpauth://totp/bar:foo?secret=' . $testsecret . '&algorithm=SHA1&digits=6&period=30';
+        $exp = 'otpauth://' . $type . '/bar:foo?secret=' . $testsecret . '&algorithm=SHA1&digits=6';
+        if ($issuer) {
+            $exp .= '&issuer=' . $issuer;
+        }
+        if ($type == 'totp') {
+            $exp .= '&period=30';
+        } elseif ($type == 'hotp') {
+            $exp .= '&counter=1';
+        }
 
         $s = new Secret();
         $s->secret = $testsecret;
         $s->digits = 6;
-        $s->mode = 'totp';
+        $s->mode = $type;
         $s->algo = 'SHA1';
         $s->period = 30;
         $s->save();
 
-        ob_start();
-        $img = QRCodeimg::widget([
+        $opts = [
             'sid' => $s->id,
             'username' => 'foo',
             'label' => 'bar'
-        ]);
+        ];
+
+        if ($issuer) {
+            $opts['issuer'] = $issuer;
+        }
+
+        ob_start();
+        $img = QRCodeimg::widget($opts);
         ob_end_clean();
 
         // Extract the image

--- a/tests/QRCodeimgTest.php
+++ b/tests/QRCodeimgTest.php
@@ -6,6 +6,7 @@ use chillerlan\Authenticator\Base32;
 use Zxing\QrReader;
 use madpilot78\otputil\models\Secret;
 use madpilot78\otputil\widgets\QRCodeimg;
+use yii\web\ServerErrorHttpException;
 
 class QRCodeimgTest extends TestCase
 {
@@ -78,5 +79,146 @@ class QRCodeimgTest extends TestCase
         $qrreader = new QrReader($imgdata, QrReader::SOURCE_TYPE_BLOB);
 
         $this->assertEquals($exp, $qrreader->text());
+    }
+
+    /**
+     * Test wrong image format causes exception
+     *
+     * @return void
+     */
+    public function testWrongImageFormatException()
+    {
+        $this->expectException(ServerErrorHttpException::class);
+
+        $base32 = new Base32();
+        $testsecret = $base32->fromString(random_bytes(20));
+
+        $s = new Secret();
+        $s->secret = $testsecret;
+        $s->digits = 6;
+        $s->mode = 'totp';
+        $s->algo = 'SHA1';
+        $s->period = 30;
+        $s->save();
+
+        $img = QRCodeimg::widget([
+            'sid' => $s->id,
+            'fmt' => 'unkn',
+            'username' => 'foo',
+            'label' => 'bar'
+        ]);
+    }
+
+    /**
+     * Test wrong error correction level causes exception
+     *
+     * @return void
+     */
+    public function testWrongecLevelException()
+    {
+        $this->expectException(ServerErrorHttpException::class);
+
+        $base32 = new Base32();
+        $testsecret = $base32->fromString(random_bytes(20));
+
+        $s = new Secret();
+        $s->secret = $testsecret;
+        $s->digits = 6;
+        $s->mode = 'totp';
+        $s->algo = 'SHA1';
+        $s->period = 30;
+        $s->save();
+
+        $img = QRCodeimg::widget([
+            'sid' => $s->id,
+            'ecLevel' => 'X',
+            'username' => 'foo',
+            'label' => 'bar'
+        ]);
+    }
+
+    /**
+     * Test username with colon causes exception
+     *
+     * @return void
+     */
+    public function testColonInUsernameException()
+    {
+        $this->expectException(ServerErrorHttpException::class);
+
+        $base32 = new Base32();
+        $testsecret = $base32->fromString(random_bytes(20));
+
+        $s = new Secret();
+        $s->secret = $testsecret;
+        $s->digits = 6;
+        $s->mode = 'totp';
+        $s->algo = 'SHA1';
+        $s->period = 30;
+        $s->save();
+
+        $img = QRCodeimg::widget([
+            'sid' => $s->id,
+            'username' => 'f:oo',
+            'label' => 'bar'
+        ]);
+    }
+
+    /**
+     * Test label with colon causes exception
+     *
+     * @return void
+     */
+    public function testColonInLabelException()
+    {
+        $this->expectException(ServerErrorHttpException::class);
+
+        $base32 = new Base32();
+        $testsecret = $base32->fromString(random_bytes(20));
+
+        $s = new Secret();
+        $s->secret = $testsecret;
+        $s->digits = 6;
+        $s->mode = 'totp';
+        $s->algo = 'SHA1';
+        $s->period = 30;
+        $s->save();
+
+        $img = QRCodeimg::widget([
+            'sid' => $s->id,
+            'username' => 'foo',
+            'label' => 'ba:r'
+        ]);
+    }
+
+    /**
+     * Test wrong sid causes exception
+     *
+     * @return void
+     */
+    public function testWrongSidException()
+    {
+        $this->expectException(ServerErrorHttpException::class);
+
+        $img = QRCodeimg::widget([
+            'sid' => 42,
+            'username' => 'foo',
+            'label' => 'bar'
+        ]);
+    }
+
+    /**
+     * Test null sid causes exception
+     *
+     * @return void
+     */
+    public function testNullSidException()
+    {
+        $this->expectException(ServerErrorHttpException::class);
+
+        $img = QRCodeimg::widget([
+            'username' => 'foo',
+            'label' => 'bar'
+        ]);
     }
 }

--- a/tests/ScratchTest.php
+++ b/tests/ScratchTest.php
@@ -207,6 +207,17 @@ class ScratchTest extends TestCase
     }
 
     /**
+     * Test verifying Scratch with invalid Secret ID
+     *
+     * @return void
+     */
+    public function testVerifyCratchCodeWithInvalidSIDOnInstance()
+    {
+        $c = new Scratch(42);
+        $this->assertNotTrue($c->verify('00000000'));
+    }
+
+    /**
      * Test Verifying a scratch code requesting not to delete it suceeds
      * and does not delete the code
      *


### PR DESCRIPTION
Add tests to cover more code.

Use PHPUnit ignore comments to skip untestable or uninteresting code from the coverage accounting.